### PR TITLE
add $PATH, $GOPATH mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This project exists to combine:
 
 [![asciicast](https://asciinema.org/a/BU00aXIcZV9bYWRko7i7LnugY.png)](https://asciinema.org/a/BU00aXIcZV9bYWRko7i7LnugY)
 
+Make sure to setup your [$GOPATH](https://golang.org/doc/code.html#GOPATH) correctly, including the `bin` subdirectory in your `$PATH`.
+
 ```
 go install github.com/mbrt/gmailctl/cmd/gmailctl
 gmailctl init


### PR DESCRIPTION
Link to Go docs as proposed by @mbrt, use text by @mbrt 

replaces #9 