### PR TITLE
Support Gmail's "forward" action (for forwarding emails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ are the same as the ones in the Gmail interface:
   that these labels have to be already present in your settings (they won't be
   created automatically), and you can specify multiple labels (normally Gmail
   allows to specify only one label per filter).
+* `forward: 'forward@to.com'`: forward the message to another email address.
+  The forwarding address must be already in your settings
+  (Forwarding and POP/IMAP > Add a forwarding address). Gmail allows no more
+  than 20 filters with a forward.
 
 Example:
 

--- a/pkg/config/v1alpha2/config.go
+++ b/pkg/config/v1alpha2/config.go
@@ -140,6 +140,8 @@ type Actions struct {
 
 	Category gmail.Category `yaml:"category,omitempty"`
 	Labels   []string       `yaml:"labels,omitempty"`
+
+	Forward string `yaml:"forward,omitempty"`
 }
 
 // Empty returns true if no actions are specified.

--- a/pkg/export/api/api_export.go
+++ b/pkg/export/api/api_export.go
@@ -80,6 +80,7 @@ func (de defaultExporter) exportAction(action filter.Actions, lmap LabelMap) (*g
 	return &gmailv1.FilterAction{
 		AddLabelIds:    lops.addLabels,
 		RemoveLabelIds: lops.removeLabels,
+		Forward:        action.Forward,
 	}, nil
 }
 

--- a/pkg/export/api/api_export_test.go
+++ b/pkg/export/api/api_export_test.go
@@ -25,6 +25,7 @@ func TestExportActions(t *testing.T) {
 				MarkNotSpam:   true,
 				MarkImportant: true,
 				Category:      gmail.CategoryUpdates,
+				Forward:       "baz@zuz.it",
 			},
 			Criteria: filter.Criteria{
 				From: "foo@bar.com",
@@ -46,6 +47,7 @@ func TestExportActions(t *testing.T) {
 					labelIDUnread,
 					labelIDSpam,
 				},
+				Forward: "baz@zuz.it",
 			},
 			Criteria: &gmailv1.FilterCriteria{
 				From: "foo@bar.com",

--- a/pkg/export/api/api_import.go
+++ b/pkg/export/api/api_import.go
@@ -68,8 +68,11 @@ func (di defaultImporter) importAction(action *gmailv1.FilterAction, lmap LabelM
 	if err := di.importAddLabels(&res, action.AddLabelIds, lmap); err != nil {
 		return res, err
 	}
-	err := di.importRemoveLabels(&res, action.RemoveLabelIds)
-	return res, err
+	if err := di.importRemoveLabels(&res, action.RemoveLabelIds); err != nil {
+		return res, err
+	}
+	res.Forward = action.Forward
+	return res, nil
 }
 
 func (di defaultImporter) importAddLabels(res *filter.Actions, addLabelIDs []string, lmap LabelMap) error {

--- a/pkg/export/api/api_import_test.go
+++ b/pkg/export/api/api_import_test.go
@@ -25,6 +25,7 @@ func TestImportActions(t *testing.T) {
 					labelIDUnread,
 					labelIDSpam,
 				},
+				Forward: "baz@zuz.it",
 			},
 			Criteria: &gmailv1.FilterCriteria{
 				From: "foo@bar.com",
@@ -42,6 +43,7 @@ func TestImportActions(t *testing.T) {
 				MarkNotSpam:   true,
 				MarkImportant: true,
 				Category:      gmail.CategoryUpdates,
+				Forward:       "baz@zuz.it",
 			},
 			Criteria: filter.Criteria{
 				From: "foo@bar.com",

--- a/pkg/export/xml/consts.go
+++ b/pkg/export/xml/consts.go
@@ -24,6 +24,7 @@ const (
 	PropertyMarkRead         = "shouldMarkAsRead"
 	PropertyMarkNotSpam      = "shouldNeverSpam"
 	PropertyStar             = "shouldStar"
+	PropertyForward          = "forwardTo"
 )
 
 // SmartLabel values

--- a/pkg/export/xml/marshal.go
+++ b/pkg/export/xml/marshal.go
@@ -143,6 +143,7 @@ func (x xmlExporter) actionProperties(a filter.Actions) ([]xmlProperty, error) {
 	res = x.appendBoolProperty(res, PropertyMarkNotSpam, a.MarkNotSpam)
 	res = x.appendBoolProperty(res, PropertyStar, a.Star)
 	res = x.appendStringProperty(res, PropertyApplyLabel, a.AddLabel)
+	res = x.appendStringProperty(res, PropertyForward, a.Forward)
 
 	if a.Category != "" {
 		cat, err := categoryToSmartLabel(a.Category)

--- a/pkg/export/xml/marshal_test.go
+++ b/pkg/export/xml/marshal_test.go
@@ -106,6 +106,7 @@ func TestAllEntries(t *testing.T) {
 				MarkRead:      true,
 				Category:      gmail.CategoryPromotions,
 				AddLabel:      "MyLabel",
+				Forward:       "baz@zuz.it",
 			},
 			Criteria: filter.Criteria{
 				From:    "foo@baz.com",
@@ -141,6 +142,7 @@ func TestAllEntries(t *testing.T) {
     <apps:property name="shouldAlwaysMarkAsImportant" value="true"></apps:property>
     <apps:property name="shouldMarkAsRead" value="true"></apps:property>
     <apps:property name="label" value="MyLabel"></apps:property>
+    <apps:property name="forwardTo" value="baz@zuz.it"></apps:property>
     <apps:property name="smartLabelToApply" value="^smartlabel_promo"></apps:property>
   </entry>
 </feed>`

--- a/pkg/filter/convert.go
+++ b/pkg/filter/convert.go
@@ -264,6 +264,7 @@ func generateActions(actions parser.Actions) ([]Actions, error) {
 			Category:         actions.Category,
 			MarkNotSpam:      fromOptionalBool(actions.MarkSpam, false),
 			Star:             actions.Star,
+			Forward:          actions.Forward,
 		},
 	}
 

--- a/pkg/filter/convert_test.go
+++ b/pkg/filter/convert_test.go
@@ -223,6 +223,7 @@ func TestActions(t *testing.T) {
 				MarkSpam:      boolptr(false),
 				MarkImportant: boolptr(true),
 				Category:      gmail.CategoryForums,
+				Forward:       "foo@bar.com",
 			},
 		},
 	}
@@ -239,6 +240,7 @@ func TestActions(t *testing.T) {
 				MarkNotSpam:   true,
 				MarkImportant: true,
 				Category:      gmail.CategoryForums,
+				Forward:       "foo@bar.com",
 			},
 		},
 	}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -52,6 +52,7 @@ func (f Filter) String() string {
 	w.WriteBool("star", f.Action.Star)
 	w.WriteParam("categorize as", string(f.Action.Category))
 	w.WriteParam("apply label", f.Action.AddLabel)
+	w.WriteParam("forward to", f.Action.Forward)
 
 	return w.String()
 }
@@ -60,6 +61,7 @@ func (f Filter) String() string {
 type Actions struct {
 	AddLabel         string
 	Category         gmail.Category
+	Forward          string
 	Archive          bool
 	Delete           bool
 	MarkImportant    bool


### PR DESCRIPTION
Fixes #56

Example:

```sh
$ gmailctl diff
```
```diff
--- Current
+++ TO BE APPLIED
@@ -1,14 +1,21 @@
 * Criteria:
     from: rapidrewards@luv.southwest.com
-    subject: "rapid rewards report"
+    subject: "Rapid Rewards Report"
   Actions:
     archive
     forward to: redacted@AwardWallet.com

 * Criteria:
     from: mymileageplus@news.united.com
-    subject: "your monthly statement"
+    subject: "MileagePlus Statement"
   Actions:
     archive
     forward to: redacted@AwardWallet.com

+* Criteria:
+    from: mymileageplus@news.united.com
+    subject: "Your monthly statement"
+  Actions:
+    archive
+    forward to: redacted@AwardWallet.com
+
```
```sh
Do you want to apply them? [y/N]: y
Applying the changes...
$ 
```

One of my in-Gmail filters was matched exactly, so it doesn't show in the diff.

Gmail now shows 4 filters that have a forward:

```
Matches: from:(rapidrewards@luv.southwest.com) subject:("Rapid Rewards Report")
Do this: Skip Inbox, Forward to redacted@AwardWallet.com

Matches: from:(mymileageplus@news.united.com) subject:("MileagePlus Statement")
Do this: Skip Inbox, Forward to redacted@AwardWallet.com

Matches: from:(mymileageplus@news.united.com) subject:("Your monthly statement")
Do this: Skip Inbox, Forward to redacted@AwardWallet.com

Matches: from:(DeltaAirLines@e.delta.com) subject:("SkyMiles STATEMENT")
Do this: Skip Inbox, Forward to redacted@AwardWallet.com
```