### PR TITLE
Fix broken askYN on Windows

### DIFF
--- a/cmd/gmailctl/cmd/io.go
+++ b/cmd/gmailctl/cmd/io.go
@@ -12,7 +12,7 @@ func askYN(prompt string) bool {
 	for {
 		fmt.Printf("%s [y/N]: ", prompt)
 		if choice, err := r.ReadString('\n'); err == nil {
-			switch strings.ToLower(strings.TrimSuffix(choice, "\n")) {
+			switch strings.ToLower(strings.TrimRight(choice, "\r\n")) {
 			case "y", "yes":
 				return true
 			case "n", "no", "": // empty string defaults to 'no'


### PR DESCRIPTION
On Windows, `gmailctl edit` was always printing "invalid choice".

Because the switch would always use a string ending in `\r`.