### PR TITLE
Make init instructions more clear.

### DIFF
--- a/cmd/gmailctl/cmd/init_cmd.go
+++ b/cmd/gmailctl/cmd/init_cmd.go
@@ -27,15 +27,23 @@ To do so, head to https://console.developers.google.com
    2a. Select the Gmail API
    2b. Select 'Other UI'
    2c. Access 'User data'.
-3. Go to 'OAuth constent screen' and update 'Scopes for Google API', by
-   adding:
-     * https://www.googleapis.com/auth/gmail.labels
-     * https://www.googleapis.com/auth/gmail.metadata
-     * https://www.googleapis.com/auth/gmail.settings.basic
-4. IMPORTANT: you don't need to submit your changes for verification, as
-   you're not creating a public App
-5. Download the credentials file into '%s'
-   and execute the 'init' command again.
+3. Go to 'OAuth consent screen'
+   3a. If your account is managed by an organization, you have to
+       select 'Internal' as 'User Type' and Create (otherwise ignore)
+   3b. Set an application name (e.g. 'gmailctl')
+   3c. Update 'Scopes for Google API', by adding:
+       * https://www.googleapis.com/auth/gmail.labels
+       * https://www.googleapis.com/auth/gmail.metadata
+       * https://www.googleapis.com/auth/gmail.settings.basic
+5. IMPORTANT: you don't need to submit your changes for verification, as
+   you're not creating a public App.
+6. Save and go back to Credentials
+   6a. Click 'Create credentials'
+   6b. Select 'OAuth client ID'
+   6c. Select 'Other' as 'Application type' and give it a name.
+   6d. Create.
+7. Download the credentials file into '%s' and execute the 'init'
+   command again.
 
 Documentation about Gmail API authorization can be found
 at: https://developers.google.com/gmail/api/auth/about-auth


### PR DESCRIPTION
It was especially confusing for gSuite users.

Close #91.