### PR TITLE
Added a ToC in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,28 @@ It has a [Jsonnet](https://jsonnet.org/) configuration file that aims to be
 simpler to write and maintain than using the Gmail web interface, to categorize,
 label, archive and manage your inbox automatically.
 
+## Table of content
+- [Motivation](#motivation)
+- [Install](#install)
+- [Usage](#usage)
+  - [Migrate from another solution](#migrate-from-another-solution)
+  - [Other commands](#other-commands)
+- [Configuration](#configuration)
+  - [Search operators](#search-operators)
+  - [Logic operators](#logic-operators)
+  - [Reusing filters](#reusing-filters)
+  - [Actions](#actions)
+  - [Labels](#labels)
+  - [Tests](#tests)
+- [Tips and tricks](#tips-and-tricks)
+  - [Chain filtering](#chain-filtering)
+  - [To me](#to-me)
+  - [Directly to me](#directly-to-me)
+  - [Automatic labels](#automatic-labels)
+  - [Multiple Gmail accounts](#multiple-gmail-accounts)
+- [Comparison with existing projects](#comparison-with-existing-projects)
+- [Footnotes](#footnotes)
+
 ## Motivation
 
 If you have Gmail and have to maintain (like me) a lot of filters, because you


### PR DESCRIPTION
The `README.md` file is a little lengthy, it would be nice to easily go to what you're looking for in the documentation.