### PR TITLE
Mention installation via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ go install github.com/mbrt/gmailctl/cmd/gmailctl
 gmailctl init
 ```
 
+Alternatively, if you're on macOS, you can install easily via Homebrew:
+
+```
+brew install gmailctl
+```
+
 The init will guide you through setting up the Gmail APIs and update your
 settings without leaving your command line.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ correctly, including the `bin` subdirectory in your `$PATH`.
 ```
 go get -u github.com/mbrt/gmailctl/cmd/gmailctl
 go install github.com/mbrt/gmailctl/cmd/gmailctl
-gmailctl init
 ```
 
 Alternatively, if you're on macOS, you can install easily via Homebrew:
@@ -54,7 +53,13 @@ Alternatively, if you're on macOS, you can install easily via Homebrew:
 brew install gmailctl
 ```
 
-The init will guide you through setting up the Gmail APIs and update your
+Once installed, run the init process:
+
+```
+gmailctl init
+```
+
+This will guide you through setting up the Gmail APIs and update your
 settings without leaving your command line.
 
 ## Usage


### PR DESCRIPTION
I've submitted [a pull request to Homebrew](https://github.com/Homebrew/homebrew-core/pull/52674) to add a formula for gmailctl. If it gets accepted, it would be worth mentioning this installation method for macOS users in the readme.