### PR TITLE
Error reporting

### DIFF
--- a/pkg/export/api/api_export.go
+++ b/pkg/export/api/api_export.go
@@ -1,13 +1,14 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 
 	gmailv1 "google.golang.org/api/gmail/v1"
 
+	"github.com/mbrt/gmailctl/pkg/errors"
 	"github.com/mbrt/gmailctl/pkg/filter"
 	"github.com/mbrt/gmailctl/pkg/gmail"
+	"github.com/mbrt/gmailctl/pkg/reporting"
 )
 
 // Export exports Gmail filters into Gmail API objects
@@ -16,7 +17,11 @@ func Export(filters filter.Filters, lmap LabelMap) ([]*gmailv1.Filter, error) {
 	for i, filter := range filters {
 		ef, err := export(filter, lmap)
 		if err != nil {
-			return nil, fmt.Errorf("exporting filter #%d: %w", i, err)
+			return nil, errors.WithDetails(
+				fmt.Errorf("exporting filter #%d: %w", i, err),
+				fmt.Sprintf("Filter (internal representation): %s",
+					reporting.Prettify(filter, false)),
+			)
 		}
 		res[i] = ef
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"strings"
 
 	cfg "github.com/mbrt/gmailctl/pkg/config/v1alpha3"
@@ -32,6 +32,10 @@ func Parse(config cfg.Config) ([]Rule, error) {
 		scrit, err := SimplifyCriteria(crit)
 		if err != nil {
 			return nil, fmt.Errorf("simplifying criteria for rule #%d: %w", i, err)
+		}
+
+		if rule.Actions.Empty() {
+			return nil, fmt.Errorf("parsing action for rule #%d: empty action", i)
 		}
 
 		res = append(res, Rule{

--- a/pkg/rimport/rimport.go
+++ b/pkg/rimport/rimport.go
@@ -1,13 +1,14 @@
 package rimport
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	config "github.com/mbrt/gmailctl/pkg/config/v1alpha3"
+	"github.com/mbrt/gmailctl/pkg/errors"
 	"github.com/mbrt/gmailctl/pkg/filter"
 	"github.com/mbrt/gmailctl/pkg/label"
+	"github.com/mbrt/gmailctl/pkg/reporting"
 )
 
 // Import converts a list of filters into config rules, best
@@ -17,7 +18,9 @@ func Import(fs filter.Filters, ls label.Labels) (config.Config, error) {
 	for i, f := range fs {
 		r, err := fromFilter(f)
 		if err != nil {
-			return config.Config{}, fmt.Errorf("importing filter #%d: %w", i, err)
+			return config.Config{}, errors.WithDetails(
+				fmt.Errorf("importing filter #%d: %w", i, err),
+				fmt.Sprintf("Filter (internal representation): %s", reporting.Prettify(f, false)))
 		}
 		rules = append(rules, r)
 	}


### PR DESCRIPTION
This addresses the issue reported in #53. Unfortunately syntax errors cannot be printed in a better way, because of limitations in the `jsonnet` and `encoding/json` packages.