### PR TITLE
Avoid checking go.sum

### DIFF
--- a/hack/check-codegen.sh
+++ b/hack/check-codegen.sh
@@ -4,6 +4,4 @@ set -e
 
 # check that we are not committing with things still to generate
 go generate ./...
-# `generate` adds additional dependencies that we want to remove.
-go mod tidy
-git diff --exit-code
+git diff --exit-code -- pkg/ cmd/


### PR DESCRIPTION
The purpose is checking whether the `go gen` is up to date or not, not checking whether the dependencies are 100% clean.