### PR TITLE
Fix a couple of spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mess of filters, you wish you could find-and-replace stuff, test the changes on
 your filters before applying them, refactor some filters together... in a way
 treat them like you treat your code!
 
-Gmail allows to import and export filters in XML format. This can be used to
+Gmail allows one to import and export filters in XML format. This can be used to
 maintain them in some better way... but dear Lord, no! Not by hand! That's what
 most other tools do: providing some kind of DSL that generate XML filters that
 can be imported in your settings... by hand [this is the approach of the popular
@@ -850,9 +850,9 @@ this one are:
 * `gmail-britta` uses a custom DSL (versus Jsonnet in `gmailctl`)
 * `gmail-britta` is imperative because it allows you to write arbitrary Ruby
   code in your filters (versus pure declarative for `gmailctl`)
-* `gmail-britta` allows to write complex chains of filters, but they feel very
-  hardcoded and fails to provide easy ways to write reasonably easy filters <sup
-  id="a2">[2](#f2)</sup>.
+* `gmail-britta` allows one to write complex chains of filters, but they feel
+  very hardcoded and fails to provide easy ways to write reasonably easy filters
+  <sup id="a2">[2](#f2)</sup>.
 * `gmail-britta` exports only to the Gmail XML format. You have to import the
   filters yourself by using the Gmail web interface, manually delete the filters
   you updated and import only the new ones. This process becomes tedious very

--- a/cmd/gmailctl/cmd/export_cmd.go
+++ b/cmd/gmailctl/cmd/export_cmd.go
@@ -42,7 +42,7 @@ func init() {
 
 	// Flags and configuration settings
 	exportCmd.PersistentFlags().StringVarP(&exportFilename, "filename", "f", "", "configuration file")
-	exportCmd.PersistentFlags().StringVarP(&exportOutput, "output", "o", "", "output file (defaut to stdout)")
+	exportCmd.PersistentFlags().StringVarP(&exportOutput, "output", "o", "", "output file (default to stdout)")
 	exportCmd.Flags().BoolVarP(&exportSkipTests, "yolo", "", false, "skip configuration tests")
 }
 

--- a/docs/v1alpha2.md
+++ b/docs/v1alpha2.md
@@ -335,7 +335,7 @@ are the same as the ones in the Gmail interface:
 * `labels: [list, of, labels]`: an array of labels to apply to the message. Note
   that these labels have to be already present in your settings (they won't be
   created automatically), and you can specify multiple labels (normally Gmail
-  allows to specify only one label per filter).
+  allows one to specify only one label per filter).
 
 Example:
 

--- a/pkg/filter/convert.go
+++ b/pkg/filter/convert.go
@@ -272,7 +272,7 @@ func generateActions(actions parser.Actions) ([]Actions, error) {
 	}
 
 	if fromOptionalBool(actions.MarkSpam, true) {
-		return nil, errors.New("Gmail filters don't allow to send messages to spam directly")
+		return nil, errors.New("Gmail filters don't allow one to send messages to spam directly")
 	}
 
 	if len(actions.Labels) == 0 {


### PR DESCRIPTION
Fix a typo of "default", as well as conversions of "allow(s) to" -> "allow(s) one to". Identified by Debian's lintian.