### PR TITLE
Fix doc on test message fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ as possible. This is the list of fields:
 * `to: [<list>]`: a list of recipients of the email.
 * `cc: [<list>]`: a list of emails in cc.
 * `bcc: [<list>]`: a list of emails in bcc.
-* `list: [<list>]`: a list of mailing lists.
+* `lists: [<list>]`: a list of mailing lists.
 * `subject: <string>`: the subject of the email.
 * `body: <string>`: the body of the email.
 


### PR DESCRIPTION
As defined in the struct
(https://github.com/mbrt/gmailctl/blob/master/pkg/config/v1alpha3/config.go#L185)
field name for list of mailing lists is called `lists`.
