### PR TITLE
Update CodeQL workflow.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
@@ -17,17 +17,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       

--- a/hack/check-codegen.sh
+++ b/hack/check-codegen.sh
@@ -3,5 +3,6 @@
 set -e
 
 # check that we are not committing with things still to generate
+go get github.com/go-bindata/go-bindata/go-bindata
 go generate ./...
 git diff --exit-code -- pkg/ cmd/


### PR DESCRIPTION
The analysis was complaining that `git checkout HEAD^2` is no longer
necessary:

```
 1 issue was detected with this workflow: git checkout HEAD^2 is no
   longer necessary. Please remove this step as Code Scanning recommends
   analyzing the merge commit for best results.
```