### PR TITLE
Fix testing example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Example:
   tests: [
     messages: [
       { from: "foobar" },
-      { to: "me" },
+      { to: ["me"] },
     ],
     actions: {
       // ...


### PR DESCRIPTION
The example for tests is incorrect and does not compile because the `to` field must be an array of strings. As it stands the example will result in an error `cannot unmarshal string into Go struct field Message.tests.messages.to of type []string`.

Thanks for a super valuable piece of software! I'm loving Gmailctl.