### PR TITLE
Remove unused GMail auth scope.

### DIFF
--- a/cmd/gmailctl/cmd/init_cmd.go
+++ b/cmd/gmailctl/cmd/init_cmd.go
@@ -32,7 +32,6 @@ To do so, head to https://console.developers.google.com
    3b. Set an application name (e.g. 'gmailctl').
    3c. Update 'Scopes for Google API', by adding:
        * https://www.googleapis.com/auth/gmail.labels
-       * https://www.googleapis.com/auth/gmail.metadata
        * https://www.googleapis.com/auth/gmail.settings.basic
 5. IMPORTANT: you don't need to submit your changes for verification, as
    you're only going to access your own data. Save and 'Go back to

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	gmailv1 "google.golang.org/api/gmail/v1"
+	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/googleapi"
 
 	"github.com/mbrt/gmailctl/pkg/errors"
@@ -20,18 +20,18 @@ const (
 )
 
 // NewFromService creates a new GmailAPI instance from the given Gmail service.
-func NewFromService(s *gmailv1.Service) *GmailAPI {
+func NewFromService(s *gmail.Service) *GmailAPI {
 	return &GmailAPI{s, nil}
 }
 
 // NewWithAPIKey creates a new GmailAPI instance from the given Gmail service and API key.
-func NewWithAPIKey(s *gmailv1.Service, key string) *GmailAPI {
+func NewWithAPIKey(s *gmail.Service, key string) *GmailAPI {
 	return &GmailAPI{s, []googleapi.CallOption{keyOption(key)}}
 }
 
 // GmailAPI is a wrapper around the Gmail APIs.
 type GmailAPI struct {
-	service *gmailv1.Service
+	service *gmail.Service
 	opts    []googleapi.CallOption
 }
 
@@ -162,15 +162,15 @@ func (g *GmailAPI) getLabelMap() (exportapi.LabelMap, error) {
 	return exportapi.NewLabelMap(labels), nil
 }
 
-func labelToGmailAPI(lb label.Label) *gmailv1.Label {
-	var color *gmailv1.LabelColor
+func labelToGmailAPI(lb label.Label) *gmail.Label {
+	var color *gmail.LabelColor
 	if lb.Color != nil {
-		color = &gmailv1.LabelColor{
+		color = &gmail.LabelColor{
 			BackgroundColor: lb.Color.Background,
 			TextColor:       lb.Color.Text,
 		}
 	}
-	return &gmailv1.Label{
+	return &gmail.Label{
 		Name:  lb.Name,
 		Color: color,
 	}

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -11,7 +11,7 @@ import (
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	gmailv1 "google.golang.org/api/gmail/v1"
+	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 )
 
@@ -46,7 +46,7 @@ func (a Authenticator) API(ctx context.Context, token io.Reader) (*GmailAPI, err
 		return nil, fmt.Errorf("decoding token: %w", err)
 	}
 
-	srv, err := gmailv1.NewService(ctx, option.WithTokenSource(a.cfg.TokenSource(ctx, tok)))
+	srv, err := gmail.NewService(ctx, option.WithTokenSource(a.cfg.TokenSource(ctx, tok)))
 	if err != nil {
 		return nil, fmt.Errorf("creating gmail client: %w", err)
 	}
@@ -77,9 +77,8 @@ func clientFromCredentials(credentials io.Reader) (*oauth2.Config, error) {
 		return nil, fmt.Errorf("reading credentials: %w", err)
 	}
 	return google.ConfigFromJSON(credBytes,
-		gmailv1.GmailSettingsBasicScope,
-		gmailv1.GmailMetadataScope,
-		gmailv1.GmailLabelsScope,
+		gmail.GmailSettingsBasicScope,
+		gmail.GmailLabelsScope,
 	)
 }
 


### PR DESCRIPTION
The GmailMetatadaScope is a leftover from the beginning of times and
it's not realy necessary.

No APIs gmailctl is using require the scope, so it was removed.

Follow up from #204.