### PR TITLE
Update authorization workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /gmailctl
 mycfg.jsonnet
 *.snap
+/tmp

--- a/README.md
+++ b/README.md
@@ -872,6 +872,38 @@ feature. If you really want to do this, you can manually export your rules with
 `gmailctl export > filters.xml`, upload them by using the Gmail Settings UI and
 select the "apply new filters to existing email" checkbox.
 
+### OAuth2 authentication errors
+
+Gmail APIs require strict controls, even if you are only accessing your own
+data. If you're getting errors similar to:
+
+```
+oauth2: cannot fetch token: 400 Bad Request
+Response: {
+  "error": "invalid_grant",
+  "error_description": "Bad Request"
+}
+```
+
+it's likely your auth token expired. Try refreshing it with:
+
+```bash
+$ gmailctl init --refresh-expired
+```
+
+and follow the instructions on screen.
+
+If this doesn't help, retry the authorization workflow from the start:
+
+```bash
+$ gmailctl init --reset
+$ gmailctl init
+```
+
+If authentication never worked, it may be that there's a mistake in the
+configuration of your GCP project. Please start from scratch with a new project
+and follow the instructions of `gmailctl init`.
+
 ### YAML config is unsupported
 
 gmailctl recently deprecated older config versions (`v1alpha1`, `v1alpha2`).

--- a/README.md
+++ b/README.md
@@ -900,10 +900,6 @@ $ gmailctl init --reset
 $ gmailctl init
 ```
 
-If authentication never worked, it may be that there's a mistake in the
-configuration of your GCP project. Please start from scratch with a new project
-and follow the instructions of `gmailctl init`.
-
 ### YAML config is unsupported
 
 gmailctl recently deprecated older config versions (`v1alpha1`, `v1alpha2`).

--- a/cmd/gmailctl/localcred/local_provider.go
+++ b/cmd/gmailctl/localcred/local_provider.go
@@ -43,11 +43,20 @@ To do so, head to https://console.developers.google.com
    6b. Select 'OAuth client ID'.
    6c. Select 'Desktop app' as 'Application type' and give it a name.
    6d. Create.
-7. Download the credentials file into '%s' and execute the 'init'
+7. Download the credentials file into %q and execute the 'init'
    command again.
 
 Documentation about Gmail API authorization can be found
 at: https://developers.google.com/gmail/api/auth/about-auth
+`
+	authMessage = `Go to the following link in your browser and authorize gmailctl:
+
+%v
+
+NOTE that gmailctl runs a webserver on your local machine to
+collect the token as returned from Google. This only runs until
+the token is saved. If your browser is on another machine
+without access to the local network, this will not work.
 `
 )
 
@@ -131,12 +140,7 @@ func setupToken(auth *api.Authenticator, path string) error {
 	}
 	defer localSrv.Close()
 
-	fmt.Printf("Go to the following link in your browser and authorize gmailctl: \n"+
-		"%v\n\n"+
-		"NOTE: If you are running on a remote machine this will not work.\n"+
-		"Please execute this command on your desktop and copy the\n"+
-		"credentials to the remote machine.\n", auth.AuthURL("http://"+addr))
-
+	fmt.Printf(authMessage, auth.AuthURL("http://"+addr))
 	authCode := localSrv.WaitForCode()
 	if err := saveToken(path, authCode, auth); err != nil {
 		return fmt.Errorf("caching token: %w", err)
@@ -152,7 +156,7 @@ func saveToken(path, authCode string, auth *api.Authenticator) (err error) {
 	}
 	defer func() {
 		e = f.Close()
-		// do not hide more important error
+		// Do not hide more important errors.
 		if err == nil {
 			err = e
 		}

--- a/cmd/gmailctl/localcred/local_provider.go
+++ b/cmd/gmailctl/localcred/local_provider.go
@@ -14,36 +14,39 @@ import (
 )
 
 const (
+	// Keep in sync with https://rclone.org/drive/#making-your-own-client-id.
+	// They hit the exact same issues with Google Drive.
 	credentialsMissingMsg = `The credentials are not initialized.
 
 To do so, head to https://console.developers.google.com
 
 1. Create a new project if you don't have one.
-1. Go to 'Enable API and services' and select Gmail.
-2. Go to credentials and create a new one, by selecting 'Help me choose'.
-   2a. Select the Gmail API.
-   2b. Select 'Other UI'.
-   2c. Access 'User data'.
-3. Go to 'OAuth consent screen'.
-   3a. If your account is managed by an organization, you have to
-       select 'Internal' as 'User Type' and Create (otherwise ignore).
-   3b. Set an application name (e.g. 'gmailctl').
-   3c. Update 'Scopes for Google API', by adding:
-       * https://www.googleapis.com/auth/gmail.labels
-       * https://www.googleapis.com/auth/gmail.settings.basic
-5. IMPORTANT: you don't need to submit your changes for verification, as
-   you're only going to access your own data. Save and 'Go back to
-   Dashboard'.
-   5a. Make sure that the 'Publishing status' is set to 'In production'.
-       If it's set to 'Testing', Publish the app and ignore the
-	   verification. Using the testing mode will make your tokens
-	   expire every 7 days and require re-authentication.
-6. Go back to Credentials.
-   6a. Click 'Create credentials'.
-   6b. Select 'OAuth client ID'.
-   6c. Select 'Desktop app' as 'Application type' and give it a name.
-   6d. Create.
-7. Download the credentials file into %q and execute the 'init'
+1. Go to 'Enable API and services', search for Gmail and enable it.
+2. Go to 'OAuth consent screen'.
+   	2a. If your account is managed by an organization you have to
+        select 'Internal' as 'User Type'. For individual accounts
+	    select 'External'.
+    2b. Set an application name (e.g. 'gmailctl').
+    2c. Use your email for 'User support email' and 'Developer
+        contact information'. Save and continue.
+    3c. Select 'Add or remove scopes' and add:
+        * https://www.googleapis.com/auth/gmail.labels
+        * https://www.googleapis.com/auth/gmail.settings.basic
+    3d. Save and continue until you're back to the dashboard.
+3. You now have a choice. You can
+   	* Either click on 'Publish App' and avoid 'Submitting for
+   	  verification'. This will result in scary confirmation
+   	  screens or error messaages when you authorize gmailctl with
+   	  your account (but for some users it works), OR
+   	* You could add your email as 'Test user'. In this case
+   	  everything will work, but you'll have to login and confirm
+	  the access every week (token expiration).
+4. 	Go to Credentials on the left.
+   	4a. Click 'Create credentials'.
+   	4b. Select 'OAuth client ID'.
+   	4c. Select 'Desktop app' as 'Application type' and give it a name.
+   	4d. Create.
+5. Download the credentials file into %q and execute the 'init'
    command again.
 
 Documentation about Gmail API authorization can be found

--- a/cmd/gmailctl/localcred/local_provider.go
+++ b/cmd/gmailctl/localcred/local_provider.go
@@ -23,9 +23,9 @@ To do so, head to https://console.developers.google.com
 1. Create a new project if you don't have one.
 1. Go to 'Enable API and services', search for Gmail and enable it.
 2. Go to 'OAuth consent screen'.
-   	2a. If your account is managed by an organization you have to
+    2a. If your account is managed by an organization, you have to
         select 'Internal' as 'User Type'. For individual accounts
-	    select 'External'.
+        select 'External'.
     2b. Set an application name (e.g. 'gmailctl').
     2c. Use your email for 'User support email' and 'Developer
         contact information'. Save and continue.
@@ -33,19 +33,20 @@ To do so, head to https://console.developers.google.com
         * https://www.googleapis.com/auth/gmail.labels
         * https://www.googleapis.com/auth/gmail.settings.basic
     3d. Save and continue until you're back to the dashboard.
-3. You now have a choice. You can
-   	* Either click on 'Publish App' and avoid 'Submitting for
-   	  verification'. This will result in scary confirmation
-   	  screens or error messaages when you authorize gmailctl with
-   	  your account (but for some users it works), OR
-   	* You could add your email as 'Test user'. In this case
-   	  everything will work, but you'll have to login and confirm
-	  the access every week (token expiration).
-4. 	Go to Credentials on the left.
-   	4a. Click 'Create credentials'.
-   	4b. Select 'OAuth client ID'.
-   	4c. Select 'Desktop app' as 'Application type' and give it a name.
-   	4d. Create.
+3. You now have a choice. You can either:
+    * Click on 'Publish App' and avoid 'Submitting for
+      verification'. This will result in scary confirmation
+      screens or error messaages when you authorize gmailctl with
+      your account (but for some users it works), OR
+    * You could add your email as 'Test user' and keep the app in
+      'Testing' mode. In this case everything will work, but
+      you'll have to login and confirm the access every week (token
+      expiration).
+4.  Go to Credentials on the left.
+    4a. Click 'Create credentials'.
+    4b. Select 'OAuth client ID'.
+    4c. Select 'Desktop app' as 'Application type' and give it a name.
+    4d. Create.
 5. Download the credentials file into %q and execute the 'init'
    command again.
 

--- a/cmd/gmailctl/localcred/oauth2_server.go
+++ b/cmd/gmailctl/localcred/oauth2_server.go
@@ -1,0 +1,69 @@
+package localcred
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+)
+
+const successMsg = `Successfully authenticated with Google OAuth2.
+You may now close this page and return to the terminal.
+`
+
+type oauth2Server struct {
+	srv  *http.Server
+	code chan string
+}
+
+func newOauth2Server(expectedState string) *oauth2Server {
+	ch := make(chan string)
+
+	return &oauth2Server{
+		code: ch,
+		srv: &http.Server{
+			Addr: ":0",
+			Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				if err := req.ParseForm(); err != nil {
+					resp.Write([]byte(err.Error()))
+					resp.WriteHeader(400)
+					return
+				}
+				state := req.Form.Get("state")
+				if state != expectedState {
+					resp.Write([]byte("Invalid state"))
+					resp.WriteHeader(400)
+					return
+				}
+				code := req.Form.Get("code")
+				if code == "" {
+					resp.Write([]byte("Missing code in request"))
+					resp.WriteHeader(400)
+					return
+				}
+				ch <- code
+				close(ch)
+
+				resp.Header().Add("Content-Type", "text/plain")
+				resp.WriteHeader(200)
+				resp.Write([]byte(successMsg))
+			}),
+		},
+	}
+}
+
+func (s *oauth2Server) Start() (string, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return "", err
+	}
+	go s.srv.Serve(l)
+	return fmt.Sprintf("localhost:%d", l.Addr().(*net.TCPAddr).Port), nil
+}
+
+func (s *oauth2Server) Close() {
+	_ = s.srv.Close()
+}
+
+func (s *oauth2Server) WaitForCode() string {
+	return <-s.code
+}

--- a/cmd/gmailctl/localcred/oauth2_server.go
+++ b/cmd/gmailctl/localcred/oauth2_server.go
@@ -42,7 +42,7 @@ func newOauth2Server(expectedState string) *oauth2Server {
 
 				resp.Header().Add("Content-Type", "text/plain")
 				resp.WriteHeader(200)
-				resp.Write([]byte(successMsg))
+				_, _ = resp.Write([]byte(successMsg))
 			}),
 		},
 	}
@@ -50,11 +50,14 @@ func newOauth2Server(expectedState string) *oauth2Server {
 
 // Start the oauth2Server asynchronously.
 func (s *oauth2Server) Start() (string, error) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", ":0") //nolint:gosec
 	if err != nil {
 		return "", err
 	}
-	go s.srv.Serve(l)
+	go func() {
+		// This always returns an error when the server is closed.
+		_ = s.srv.Serve(l)
+	}()
 	return fmt.Sprintf("localhost:%d", l.Addr().(*net.TCPAddr).Port), nil
 }
 
@@ -71,5 +74,5 @@ func (s *oauth2Server) WaitForCode() string {
 
 func writeError(resp http.ResponseWriter, err error, code int) {
 	resp.WriteHeader(code)
-	resp.Write([]byte(fmt.Sprintf("Error: %v", err)))
+	_, _ = resp.Write([]byte(fmt.Sprintf("Error: %v", err)))
 }

--- a/internal/engine/api/auth.go
+++ b/internal/engine/api/auth.go
@@ -62,7 +62,8 @@ func (a Authenticator) API(ctx context.Context, token io.Reader) (*GmailAPI, err
 
 // AuthURL returns the URL the user has to visit to authorize the
 // application and obtain an auth code.
-func (a Authenticator) AuthURL() string {
+func (a Authenticator) AuthURL(redirectURL string) string {
+	a.cfg.RedirectURL = redirectURL
 	return a.cfg.AuthCodeURL(a.State, oauth2.AccessTypeOffline)
 }
 


### PR DESCRIPTION
Google recently tightened controls on unverified apps. This caused trouble to new users creating their credentials.

The workflow now requires a local webserver and the browser from which the user authenticates needs to run on the same machine as gmailctl, every time the token needs a refresh.

Close #232, #243.