### PR TITLE
Bugfix: Second arg of As is a pointer

### DIFF
--- a/cmd/gmailctl/cmd/edit_cmd.go
+++ b/cmd/gmailctl/cmd/edit_cmd.go
@@ -178,7 +178,7 @@ func spawnEditor(path string) error {
 			return nil
 		}
 		var exitErr *exec.ExitError
-		if errors.As(err, exitErr) {
+		if errors.As(err, &exitErr) {
 			return errAbort
 		}
 	}


### PR DESCRIPTION
Fixes Issue #249
The second argument of `As` must be a pointer: https://pkg.go.dev/errors
