### PR TITLE
Fix typo in diff command description (configuaration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ All the available commands (you can also check with `gmailctl help`):
 ```
   apply       Apply a configuration file to Gmail settings
   debug       Shows an annotated version of the configuration
-  diff        Shows a diff between the local configuaration and Gmail settings
+  diff        Shows a diff between the local configuration and Gmail settings
   download    Download filters from Gmail to a local config file
   edit        Edit the configuration and apply it to Gmail
   export      Export filters into the Gmail XML format

--- a/cmd/gmailctl/cmd/diff_cmd.go
+++ b/cmd/gmailctl/cmd/diff_cmd.go
@@ -15,7 +15,7 @@ var (
 // diffCmd represents the diff command
 var diffCmd = &cobra.Command{
 	Use:   "diff",
-	Short: "Shows a diff between the local configuaration and Gmail settings",
+	Short: "Shows a diff between the local configuration and Gmail settings",
 	Long: `The diff command shows the difference between the local
 configuration and the current Gmail settings of your account.
 


### PR DESCRIPTION
* Update diff_cmd.go
* Update README.md

PS: Thank you for creating and maintaining this tool.