### PR TITLE
add Fedora Linux to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Alternatively, if you're on macOS, you can install easily via Homebrew:
 brew install gmailctl
 ```
 
+On Fedora Linux, you can install from the official repositories:
+
+```
+sudo dnf install gmailctl
+```
+
 You can also choose to install the snap:
 
 ```


### PR DESCRIPTION
I'm a Fedora Linux packager and I have just added gmailctl to the Fedora repositories.
I would appreciate you adding Fedora to the installation documentation.

Thanks,
-fuller
