### PR TITLE
snap: add network-bind plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,3 +69,6 @@ apps:
       - network
       # to make xdg-open works
       - desktop
+      # required for initialisation. The authentication process starts
+      # a temporary local HTTP server.
+      - network-bind


### PR DESCRIPTION
The Oauth dance requires a temporary local HTTP server to be started and
the current snap settings were not allowing it.
Adding network-bind to the list of connections fixes the issue.

Fixes #261

If someone wants to test:

```bash
rm -f $HOME/snap/gmailctl/current/.gmailctl/token.json
snapcraft
snap install --dangerous ./gmailctl_v0.10.4-*.snap
gmailctl init
```