### PR TITLE
Improve config tests output

### DIFF
--- a/internal/engine/cfgtest/exec_test.go
+++ b/internal/engine/cfgtest/exec_test.go
@@ -23,13 +23,82 @@ func readConfig(t *testing.T, path string) v1alpha3.Config {
 
 func TestExec(t *testing.T) {
 	tests := []struct {
-		path string
-		pass bool
+		path        string
+		numErrs     int
+		expectedOut string
 	}{
-		{path: "pass.jsonnet", pass: true},
-		{path: "invalid.jsonnet", pass: false},
-		{path: "fail.jsonnet", pass: false},
+		{path: "pass.jsonnet"},
+		{
+			path:    "invalid.jsonnet",
+			numErrs: 1,
+			expectedOut: `Failed: 1/1
+
+Failed test "both filters":
+message #0: error evaluating matching filters: conflicting filters detected: 'markImportant' is applied differently: got true and false
+Note:
+- Message: {
+    "to": [
+      "myalias@gmail.com"
+    ],
+    "lists": [
+      "list2"
+    ]
+  }
+`,
+		},
+		{
+			path:    "fail.jsonnet",
+			numErrs: 2,
+			expectedOut: `Failed: 2/2
+
+Failed test "wrong test":
+message #0: error evaluating matching filters: conflicting filters detected: 'markImportant' is applied differently: got true and false
+Note:
+- Message: {
+    "to": [
+      "myalias@gmail.com"
+    ],
+    "lists": [
+      "list2"
+    ]
+  }
+
+Failed test "another wrong test":
+multiple errors (2):
+- message #0 is going to get unexpected actions: {"markImportant":false}
+  Note:
+  - Message: {
+      "lists": [
+        "list1"
+      ]
+    }
+  - Actions:
+    --- want
+    +++ got
+    @@ -1,3 +1,3 @@
+     {
+    -  "markImportant": false
+    +  "markImportant": true
+     }
+- message #1 is going to get unexpected actions: {"markImportant":false}
+  Note:
+  - Message: {
+      "lists": [
+        "list2"
+      ]
+    }
+  - Actions:
+    --- want
+    +++ got
+    @@ -1,3 +1,3 @@
+     {
+    -  "markImportant": false
+    +  "markImportant": true
+     }
+`,
+		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {
 			cfg := readConfig(t, tc.path)
@@ -37,11 +106,10 @@ func TestExec(t *testing.T) {
 			assert.Nil(t, err)
 			rules, errs := NewFromParserRules(pres.Rules)
 			assert.Empty(t, errs)
-			err = rules.ExecTests(cfg.Tests)
-			if tc.pass {
-				assert.Nil(t, err)
-			} else {
-				assert.NotNil(t, err)
+			res := rules.ExecTests(cfg.Tests)
+			assert.Equal(t, len(res.Failed), tc.numErrs)
+			if tc.expectedOut != "" {
+				assert.Equal(t, tc.expectedOut, res.String())
 			}
 		})
 	}

--- a/internal/engine/cfgtest/testdata/fail.jsonnet
+++ b/internal/engine/cfgtest/testdata/fail.jsonnet
@@ -43,5 +43,19 @@ local filters = {
         archive: true,
       },
     },
+    {
+      name: 'another wrong test',
+      messages: [
+        {
+          lists: ['list1'],
+        },
+        {
+          lists: ['list2'],
+        },
+      ],
+      actions: {
+        markImportant: true,
+      },
+    },
   ],
 }

--- a/internal/errors/err.go
+++ b/internal/errors/err.go
@@ -45,7 +45,9 @@ func WriteDetails(w io.Writer, err error) {
 		// Append all details of this error.
 		iw := indentWriter{w}
 		for _, d := range dErr.details {
+			//nolint:errcheck
 			io.WriteString(iw, "\n- ")
+			//nolint:errcheck
 			io.WriteString(indentWriter{iw}, d)
 		}
 		// Continue down the chain.
@@ -77,7 +79,7 @@ func Combine(errs ...error) error {
 		}
 		// Flatten by taking out the multi-error from the list
 		// if any is present.
-		merr, ok := err.(multi)
+		merr, ok := err.(multi) //nolint:errorlint
 		if ok {
 			res = merr
 			continue
@@ -105,7 +107,7 @@ func Errors(err error) []error {
 	if err == nil {
 		return nil
 	}
-	merr, ok := err.(multi)
+	merr, ok := err.(multi) //nolint:errorlint
 	if !ok {
 		return []error{err}
 	}
@@ -140,6 +142,7 @@ func (m multi) Format(f fmt.State, c rune) {
 	if (c == 'v' || c == 'w') && f.Flag('+') {
 		m.writeMultiline(f)
 	} else {
+		//nolint:errcheck
 		io.WriteString(f, m.Error())
 	}
 }
@@ -148,7 +151,9 @@ func (m multi) writeMultiline(w io.Writer) {
 	fmt.Fprintf(w, "multiple errors (%d):", len(m))
 	wi := indentWriter{w}
 	for _, err := range m {
+		//nolint:errcheck
 		io.WriteString(w, "\n- ")
+		//nolint:errcheck
 		fmt.Fprintf(wi, "%+v", err)
 	}
 }
@@ -162,6 +167,7 @@ func (d detailed) Format(f fmt.State, c rune) {
 	if (c == 'v' || c == 'w') && f.Flag('+') {
 		d.writeMultiline(f)
 	} else {
+		//nolint:errcheck
 		io.WriteString(f, d.Error())
 	}
 }
@@ -172,10 +178,13 @@ func (d detailed) writeMultiline(w io.Writer) {
 		return
 	}
 
+	//nolint:errcheck
 	io.WriteString(w, "\nNote:")
 	iw := indentWriter{w}
 	for _, d := range d.details {
+		//nolint:errcheck
 		io.WriteString(w, "\n- ")
+		//nolint:errcheck
 		io.WriteString(iw, d)
 	}
 }

--- a/internal/errors/err.go
+++ b/internal/errors/err.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strings"
+	"io"
+	"sync"
 )
 
 // Aliases to the standard errors package.
@@ -14,7 +15,12 @@ var (
 	As  = errors.As
 )
 
-// New is an alias for errors.New.
+// bufferPool is a pool of bytes.Buffers.
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
 
 // WithCause annotates a symptom error with a cause.
 //
@@ -33,26 +39,145 @@ func WithDetails(err error, details ...string) error {
 	return detailed{err, details}
 }
 
-func Details(err error) string {
-	var (
-		buffer bytes.Buffer
-		dErr   detailed
-	)
+func WriteDetails(w io.Writer, err error) {
+	var dErr detailed
 	for errors.As(err, &dErr) {
 		// Append all details of this error.
+		iw := indentWriter{w}
 		for _, d := range dErr.details {
-			buffer.WriteString("\n  - ")
-			buffer.WriteString(strings.ReplaceAll(d, "\n", "\n    "))
+			io.WriteString(iw, "\n- ")
+			io.WriteString(indentWriter{iw}, d)
 		}
 		// Continue down the chain.
 		err = dErr.error
 	}
-	return buffer.String()
+}
+
+func Details(err error) string {
+	buffer := bufferPool.Get().(*bytes.Buffer)
+	WriteDetails(buffer, err)
+	res := buffer.String()
+	bufferPool.Put(buffer)
+	return res
+}
+
+func Combine(errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	var (
+		res    multi
+		others []error
+	)
+	for _, err := range errs {
+		// Combine only the non-nil errors.
+		if err == nil {
+			continue
+		}
+		// Flatten by taking out the multi-error from the list
+		// if any is present.
+		merr, ok := err.(multi)
+		if ok {
+			res = merr
+			continue
+		}
+		others = append(others, err)
+	}
+
+	// If we found a multierror, return that and append the rest.
+	if res != nil {
+		return append(res, others...)
+	}
+
+	// Check the others.
+	if len(others) == 0 {
+		return nil
+	}
+	if len(others) == 1 {
+		return others[0]
+	}
+
+	return multi(others)
+}
+
+func Errors(err error) []error {
+	if err == nil {
+		return nil
+	}
+	merr, ok := err.(multi)
+	if !ok {
+		return []error{err}
+	}
+	return merr
+}
+
+type multi []error
+
+func (m multi) Error() string {
+	return fmt.Sprintf("multiple errors (%d); sample: %v", len(m), m[0])
+}
+
+func (m multi) Is(target error) bool {
+	for _, err := range m {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multi) As(target interface{}) bool {
+	for _, err := range m {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multi) Format(f fmt.State, c rune) {
+	if (c == 'v' || c == 'w') && f.Flag('+') {
+		m.writeMultiline(f)
+	} else {
+		io.WriteString(f, m.Error())
+	}
+}
+
+func (m multi) writeMultiline(w io.Writer) {
+	fmt.Fprintf(w, "multiple errors (%d):", len(m))
+	wi := indentWriter{w}
+	for _, err := range m {
+		io.WriteString(w, "\n- ")
+		fmt.Fprintf(wi, "%+v", err)
+	}
 }
 
 type detailed struct {
 	error
 	details []string
+}
+
+func (d detailed) Format(f fmt.State, c rune) {
+	if (c == 'v' || c == 'w') && f.Flag('+') {
+		d.writeMultiline(f)
+	} else {
+		io.WriteString(f, d.Error())
+	}
+}
+
+func (d detailed) writeMultiline(w io.Writer) {
+	fmt.Fprintf(w, "%+v", d.error)
+	if len(d.details) == 0 {
+		return
+	}
+
+	io.WriteString(w, "\nNote:")
+	iw := indentWriter{w}
+	for _, d := range d.details {
+		io.WriteString(w, "\n- ")
+		io.WriteString(iw, d)
+	}
 }
 
 type annotated struct {
@@ -61,7 +186,7 @@ type annotated struct {
 }
 
 func (e annotated) Error() string {
-	return fmt.Sprintf("%s: %s", e.cause, e.symptom)
+	return fmt.Sprintf("%v: %v", e.cause, e.symptom)
 }
 
 func (e annotated) Unwrap() error {
@@ -77,4 +202,38 @@ func (e annotated) As(target interface{}) bool {
 		return true
 	}
 	return errors.As(e.cause, target)
+}
+
+type indentWriter struct {
+	io.Writer
+}
+
+func (w indentWriter) Write(b []byte) (int, error) {
+	num := 0
+	write := func(b []byte) error {
+		n, err := w.Writer.Write(b)
+		num += n
+		return err
+	}
+
+	i, j := 0, 0
+	for i < len(b) {
+		if b[i] == '\n' {
+			// Write the indentation.
+			if err := write([]byte("\n  ")); err != nil {
+				return num, err
+			}
+			i++
+		}
+		// Look for the next newline.
+		for j = i; j < len(b) && b[j] != '\n'; j++ {
+		}
+		// Write everything up to the newline, or the end of buffer.
+		if err := write(b[i:j]); err != nil {
+			return num, err
+		}
+		i = j
+	}
+
+	return num, nil
 }


### PR DESCRIPTION
When running `gmactl test`, do not exit after the first error, but accumulate all the errors.