### PR TITLE
Reverse "want" and "got" in test failures

### DIFF
--- a/cmd/gmailctl-config-migrate/import.go
+++ b/cmd/gmailctl-config-migrate/import.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 
@@ -35,7 +35,7 @@ func importConfig(path string, out io.Writer) error {
 
 func readConfig(path string) (v1alpha3.Config, error) {
 	/* #nosec */
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return v1alpha3.Config{}, err
 	}

--- a/cmd/gmailctl-config-migrate/v1alpha2/import_test.go
+++ b/cmd/gmailctl-config-migrate/v1alpha2/import_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -16,7 +16,7 @@ import (
 )
 
 func read(path string) io.Reader {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/gmailctl-config-migrate/v1alpha3/import_test.go
+++ b/cmd/gmailctl-config-migrate/v1alpha3/import_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -18,7 +18,7 @@ import (
 )
 
 func read(path string) io.Reader {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/gmailctl/cmd/edit_cmd.go
+++ b/cmd/gmailctl/cmd/edit_cmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -122,7 +121,7 @@ func edit(path string, test bool) error {
 func moveFile(from, to string) error {
 	// Swap the configuration files. Since these two can be in different
 	// filesystems, we need to rewrite the file, instead of a simple rename.
-	b, err := ioutil.ReadFile(from)
+	b, err := os.ReadFile(from)
 	if err != nil {
 		return err
 	}
@@ -138,13 +137,13 @@ func moveFile(from, to string) error {
 }
 
 func copyToTmp(path string) (string, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return "", errors.WithCause(err, config.ErrNotFound)
 	}
 
 	// Use the same extension as the original file.
-	tmp, err := ioutil.TempFile("", fmt.Sprintf("gmailctl-*%s", filepath.Ext(path)))
+	tmp, err := os.CreateTemp("", fmt.Sprintf("gmailctl-*%s", filepath.Ext(path)))
 	if err != nil {
 		return "", fmt.Errorf("creating tmp file: %w", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -95,26 +95,26 @@ func TestIntegration(t *testing.T) {
 			// Compare the results with the golden files (or update the golden files).
 			if *update {
 				// Import.
-				err := ioutil.WriteFile(name+".json", icfgJSON, 0o600)
+				err := os.WriteFile(name+".json", icfgJSON, 0o600)
 				require.Nil(t, err)
 				// Diff.
-				err = ioutil.WriteFile(name+".diff", []byte(d.String()), 0o600)
+				err = os.WriteFile(name+".diff", []byte(d.String()), 0o600)
 				require.Nil(t, err)
 				// Export.
-				err = ioutil.WriteFile(name+".xml", cfgxml.Bytes(), 0o600)
+				err = os.WriteFile(name+".xml", cfgxml.Bytes(), 0o600)
 				require.Nil(t, err)
 				return
 			}
 			// Import.
-			b, err := ioutil.ReadFile(name + ".json")
+			b, err := os.ReadFile(name + ".json")
 			require.Nil(t, err)
 			assert.Equal(t, string(b), string(icfgJSON))
 			// Diff.
-			b, err = ioutil.ReadFile(name + ".diff")
+			b, err = os.ReadFile(name + ".diff")
 			require.Nil(t, err)
 			assert.Equal(t, string(b), d.String())
 			// Export
-			b, err = ioutil.ReadFile(name + ".xml")
+			b, err = os.ReadFile(name + ".xml")
 			require.Nil(t, err)
 			assert.Equal(t, string(b), cfgxml.String())
 		})

--- a/internal/data/lib_test.go
+++ b/internal/data/lib_test.go
@@ -3,7 +3,7 @@ package data
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -45,7 +45,7 @@ func allTestPaths(t *testing.T) testPaths {
 
 func read(t *testing.T, path string) []byte {
 	t.Helper()
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestJsonnetLib(t *testing.T) {
 				// Update the golden files
 				buf, err := json.MarshalIndent(jnparsed, "", "  ")
 				assert.Nil(t, err)
-				err = ioutil.WriteFile(jsfile, buf, 0600)
+				err = os.WriteFile(jsfile, buf, 0600)
 				assert.Nil(t, err)
 			} else {
 				// Test them

--- a/internal/engine/api/auth.go
+++ b/internal/engine/api/auth.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -79,7 +78,7 @@ func (a Authenticator) CacheToken(ctx context.Context, authCode string, token io
 }
 
 func clientFromCredentials(credentials io.Reader) (*oauth2.Config, error) {
-	credBytes, err := ioutil.ReadAll(credentials)
+	credBytes, err := io.ReadAll(credentials)
 	if err != nil {
 		return nil, fmt.Errorf("reading credentials: %w", err)
 	}

--- a/internal/engine/cfgtest/cfgtest.go
+++ b/internal/engine/cfgtest/cfgtest.go
@@ -96,8 +96,8 @@ func (rs Rules) ExecTest(t v1alpha3.Test) []error {
 
 		// Report the error.
 		diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-			A:        difflib.SplitLines(reporting.Prettify(expected, false)),
-			B:        difflib.SplitLines(reporting.Prettify(t.Actions, false)),
+			A:        difflib.SplitLines(reporting.Prettify(t.Actions, false)),
+			B:        difflib.SplitLines(reporting.Prettify(expected, false)),
 			FromFile: "want",
 			ToFile:   "got",
 			Context:  5,

--- a/internal/engine/cfgtest/exec_test.go
+++ b/internal/engine/cfgtest/exec_test.go
@@ -77,8 +77,8 @@ multiple errors (2):
     +++ got
     @@ -1,3 +1,3 @@
      {
-    -  "markImportant": false
-    +  "markImportant": true
+    -  "markImportant": true
+    +  "markImportant": false
      }
 - message #1 is going to get unexpected actions: {"markImportant":false}
   Note:
@@ -92,8 +92,8 @@ multiple errors (2):
     +++ got
     @@ -1,3 +1,3 @@
      {
-    -  "markImportant": false
-    +  "markImportant": true
+    -  "markImportant": true
+    +  "markImportant": false
      }
 `,
 		},

--- a/internal/engine/config/read.go
+++ b/internal/engine/config/read.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -30,7 +30,7 @@ var ErrNotFound = errors.New("config not found")
 // their location can be specified with cfgDirs.
 func ReadFile(path, libPath string) (v1alpha3.Config, error) {
 	/* #nosec */
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return v1alpha3.Config{}, errors.WithCause(err, ErrNotFound)
 	}


### PR DESCRIPTION
Suppose we have a rule configured to label messages with `oops-bad-label`, and a test that checks they're labeled with `yep-correct-label`. So before this change you would get:

    --- want
    +++ got
    ...
      "labels": [
    -   "oops-bad-label"
    +   "yep-correct-label"
      ]

To make this match the usual logic of automated testing (especially Go's "want" and "got"), we would like the "want" section to be "what the test describes should happen". Therefore, with this change, we get this output:

    --- want
    +++ got
    ...
      "labels": [
    -   "yep-correct-label"
    +   "oops-bad-label"
      ]