### PR TITLE
Fix buffer handling in internal/errors.

### DIFF
--- a/internal/errors/err.go
+++ b/internal/errors/err.go
@@ -59,6 +59,7 @@ func Details(err error) string {
 	buffer := bufferPool.Get().(*bytes.Buffer)
 	WriteDetails(buffer, err)
 	res := buffer.String()
+	buffer.Reset()
 	bufferPool.Put(buffer)
 	return res
 }


### PR DESCRIPTION
The buffer pool wasn't correctly used, as buffers were put back in
without being reset. This would result in errors with stale descriptions
coming from previous errors.