### PR TITLE
Quote plus sign automatically.

### DIFF
--- a/internal/engine/filter/convert_test.go
+++ b/internal/engine/filter/convert_test.go
@@ -13,23 +13,29 @@ func boolptr(a bool) *bool {
 	return &a
 }
 
-func TestSimpleFilter(t *testing.T) {
+func TestQuotes(t *testing.T) {
 	rules := []parser.Rule{
 		{
 			Criteria: &parser.Leaf{
 				Function: parser.FunctionFrom,
 				Grouping: parser.OperationOr,
-				Args:     []string{"a", "b", "with spaces"},
+				Args: []string{
+					"a",
+					"with spaces",
+					"with+plus",
+					"with+plus@email.com",
+				},
 			},
 			Actions: parser.Actions{
 				Archive: true,
 			},
 		},
 	}
+	// The plus sign is quoted, except for when in full email addresses.
 	expected := Filters{
 		{
 			Criteria: Criteria{
-				From: `{a b "with spaces"}`,
+				From: `{a "with spaces" "with+plus" with+plus@email.com}`,
 			},
 			Action: Actions{
 				Archive: true,


### PR DESCRIPTION
Gmail has this weird behavior:

* `from: foo+bar` is equivalent to `from:foo OR from:bar`
* `from foo+bar@google.com` is not (just searches the full address).

This change accounts for this behavior and automatically quotes the
plus sign, only when outside of full email addresses. This should match
users expectations a lot better.