### PR TITLE
Support boolean avoidSplitting property in rules

### DIFF
--- a/internal/engine/config/v1alpha3/config.go
+++ b/internal/engine/config/v1alpha3/config.go
@@ -88,8 +88,9 @@ func (f FilterNode) NonEmptyFields() []string {
 // For every email, if the filter applies correctly, then the specified actions
 // will be applied to it.
 type Rule struct {
-	Filter  FilterNode `json:"filter"`
-	Actions Actions    `json:"actions"`
+	Filter         FilterNode `json:"filter"`
+	Actions        Actions    `json:"actions"`
+	AvoidSplitting bool       `json:"avoidSplitting,omitempty"`
 }
 
 // Author represents the owner of the gmail account.

--- a/internal/engine/parser/parser.go
+++ b/internal/engine/parser/parser.go
@@ -11,8 +11,9 @@ import (
 
 // Rule is an intermediate representation of a Gmail filter.
 type Rule struct {
-	Criteria CriteriaAST
-	Actions  Actions
+	Criteria       CriteriaAST
+	Actions        Actions
+	AvoidSplitting bool
 }
 
 // Actions contains the actions to be applied to a set of emails.
@@ -53,8 +54,9 @@ func parseRule(rule cfg.Rule) (Rule, error) {
 	}
 
 	return Rule{
-		Criteria: scrit,
-		Actions:  Actions(rule.Actions),
+		Criteria:       scrit,
+		Actions:        Actions(rule.Actions),
+		AvoidSplitting: rule.AvoidSplitting,
 	}, nil
 }
 


### PR DESCRIPTION
!! TODO: Finalize naming/structure and add docs & tests. !!

This signals to the converter to avoid arbitrarily splitting "or" conditions into multiple separate filters when it's not strictly necessary to split.

Fixes #372.