### PR TITLE
Default to `~/.config/gmailctl` for newly created config dirs

### DIFF
--- a/cmd/gmailctl/cmd/root_cmd.go
+++ b/cmd/gmailctl/cmd/root_cmd.go
@@ -51,7 +51,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgDir, "config", "", "config directory (default is $HOME/.config/gmailctl unless $HOME/.gmailctl is already present)")
+	rootCmd.PersistentFlags().StringVar(&cfgDir, "config", "", "config directory (default search paths: $HOME/.gmailctl, $HOME/.config/gmailctl)")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/gmailctl/cmd/root_cmd.go
+++ b/cmd/gmailctl/cmd/root_cmd.go
@@ -51,7 +51,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgDir, "config", "", "config directory (default is $HOME/.gmailctl)")
+	rootCmd.PersistentFlags().StringVar(&cfgDir, "config", "", "config directory (default is $HOME/.config/gmailctl unless $HOME/.gmailctl is already present)")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -65,6 +65,10 @@ func initConfig() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		cfgDir = path.Join(usr.HomeDir, ".gmailctl")
+		if _, err := os.Stat(path.Join(usr.HomeDir, ".gmailctl")); err != nil && os.IsNotExist(err) {
+			cfgDir = path.Join(usr.HomeDir, ".config", "gmailctl")
+		} else {
+			cfgDir = path.Join(usr.HomeDir, ".gmailctl")
+		}
 	}
 }


### PR DESCRIPTION
This is a minimal fix for https://github.com/mbrt/gmailctl/issues/144