### PR TITLE
Add `--debug` flag to display Gmail search URL

### DIFF
--- a/cmd/gmailctl/cmd/apply_cmd.go
+++ b/cmd/gmailctl/cmd/apply_cmd.go
@@ -14,6 +14,7 @@ var (
 	applyYes          bool
 	applyRemoveLabels bool
 	applySkipTests    bool
+	applyDebug        bool
 )
 
 const renameLabelWarning = `Warning: You are going to delete labels. This operation is
@@ -50,6 +51,7 @@ func init() {
 	applyCmd.Flags().BoolVarP(&applyYes, "yes", "y", false, "don't ask for confirmation, just apply")
 	applyCmd.Flags().BoolVarP(&applyRemoveLabels, "remove-labels", "r", false, "allow removing labels")
 	applyCmd.Flags().BoolVarP(&applySkipTests, "yolo", "", false, "skip configuration tests")
+	applyCmd.PersistentFlags().BoolVarP(&applyDebug, "debug", "", false, "print extra debugging information")
 }
 
 func apply(path string, interactive, test bool) error {
@@ -68,7 +70,7 @@ func apply(path string, interactive, test bool) error {
 		return err
 	}
 
-	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream)
+	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, applyDebug)
 	if err != nil {
 		return fmt.Errorf("cannot compare upstream with local config: %w", err)
 	}

--- a/cmd/gmailctl/cmd/debug_cmd.go
+++ b/cmd/gmailctl/cmd/debug_cmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"net/url"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -63,10 +62,9 @@ func debug(path string) error {
 		if err != nil {
 			return fmt.Errorf("generating criteria: %w", err)
 		}
-		search := criteria.ToGmailSearch()
 
-		fmt.Printf("# Search: %s\n", search)
-		fmt.Printf("# URL: %s\n", toGmailURL(search))
+		fmt.Printf("# Search: %s\n", criteria.ToGmailSearch())
+		fmt.Printf("# URL: %s\n", criteria.ToGmailSearchURL())
 		cfg := parsedRules[i]
 		b, err := yaml.Marshal(cfg)
 		if err != nil {
@@ -76,11 +74,4 @@ func debug(path string) error {
 	}
 
 	return nil
-}
-
-func toGmailURL(s string) string {
-	return fmt.Sprintf(
-		"https://mail.google.com/mail/u/0/#search/%s",
-		url.QueryEscape(s),
-	)
 }

--- a/cmd/gmailctl/cmd/diff_cmd.go
+++ b/cmd/gmailctl/cmd/diff_cmd.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	diffFilename string
+	diffFilename  string
+	diffDebug     bool
 )
 
 // diffCmd represents the diff command
@@ -37,6 +38,7 @@ func init() {
 
 	// Flags and configuration settings
 	diffCmd.PersistentFlags().StringVarP(&diffFilename, "filename", "f", "", "configuration file")
+	diffCmd.PersistentFlags().BoolVarP(&diffDebug, "debug", "", false, "print extra debugging information")
 }
 
 func diff(path string) error {
@@ -55,7 +57,7 @@ func diff(path string) error {
 		return err
 	}
 
-	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream)
+	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, diffDebug)
 	if err != nil {
 		return fmt.Errorf("cannot compare upstream with local config: %w", err)
 	}

--- a/cmd/gmailctl/cmd/diff_cmd.go
+++ b/cmd/gmailctl/cmd/diff_cmd.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	diffFilename  string
-	diffDebug     bool
+	diffFilename string
+	diffDebug    bool
 )
 
 // diffCmd represents the diff command

--- a/cmd/gmailctl/cmd/edit_cmd.go
+++ b/cmd/gmailctl/cmd/edit_cmd.go
@@ -19,6 +19,7 @@ import (
 var (
 	editFilename  string
 	editSkipTests bool
+	editDebug     bool
 )
 
 var (
@@ -68,6 +69,7 @@ func init() {
 	// Flags and configuration settings
 	editCmd.PersistentFlags().StringVarP(&editFilename, "filename", "f", "", "configuration file")
 	editCmd.Flags().BoolVarP(&editSkipTests, "yolo", "", false, "skip configuration tests")
+	editCmd.PersistentFlags().BoolVarP(&editDebug, "debug", "", false, "print extra debugging information")
 }
 
 func edit(path string, test bool) error {
@@ -221,7 +223,7 @@ func applyEdited(path, originalPath string, test bool, gmailapi *api.GmailAPI) e
 		return err
 	}
 
-	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream)
+	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, editDebug)
 	if err != nil {
 		return errors.New("comparing upstream with local config")
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -68,7 +68,7 @@ func TestIntegration(t *testing.T) {
 			require.Nil(t, err)
 
 			// Apply the diff.
-			d, err := apply.Diff(pres.GmailConfig, upres)
+			d, err := apply.Diff(pres.GmailConfig, upres, false)
 			require.Nil(t, err)
 			err = apply.Apply(d, gapi, true)
 			require.Nil(t, err)
@@ -139,7 +139,7 @@ func TestIntegrationImportExport(t *testing.T) {
 			require.Nil(t, err)
 
 			// Apply the diff.
-			d, err := apply.Diff(pres.GmailConfig, upres)
+			d, err := apply.Diff(pres.GmailConfig, upres, false)
 			require.Nil(t, err)
 			err = apply.Apply(d, gapi, true)
 			require.Nil(t, err)
@@ -174,7 +174,7 @@ func TestIntegrationImportExport(t *testing.T) {
 }
 
 func assertEmptyDiff(t *testing.T, local, remote apply.GmailConfig) {
-	d, err := apply.Diff(local, remote)
+	d, err := apply.Diff(local, remote, false)
 	require.Nil(t, err)
 	assert.Empty(t, d.FiltersDiff)
 	assert.Empty(t, d.LabelsDiff)

--- a/internal/engine/apply/apply.go
+++ b/internal/engine/apply/apply.go
@@ -113,13 +113,13 @@ func (d ConfigDiff) Validate() error {
 }
 
 // Diff computes the diff between local and upstream configuration.
-func Diff(local, upstream GmailConfig) (ConfigDiff, error) {
+func Diff(local, upstream GmailConfig, debugInfo bool) (ConfigDiff, error) {
 	res := ConfigDiff{
 		LocalConfig: local,
 	}
 	var err error
 
-	res.FiltersDiff, err = filter.Diff(upstream.Filters, local.Filters)
+	res.FiltersDiff, err = filter.Diff(upstream.Filters, local.Filters, debugInfo)
 	if err != nil {
 		return res, fmt.Errorf("cannot compute filters diff: %w", err)
 	}

--- a/internal/engine/filter/filter.go
+++ b/internal/engine/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/mbrt/gmailctl/internal/engine/gmail"
@@ -22,6 +23,21 @@ func (fs Filters) String() string {
 		}
 		first = false
 		w.WriteString(f.String())
+	}
+
+	return w.String()
+}
+
+func (fs Filters) DebugString() string {
+	w := writer{}
+
+	first := true
+	for _, f := range fs {
+		if !first {
+			w.WriteRune('\n')
+		}
+		first = false
+		w.WriteString(f.DebugString())
 	}
 
 	return w.String()
@@ -66,6 +82,18 @@ func (f Filter) String() string {
 	w.WriteParam("categorize as", string(f.Action.Category))
 	w.WriteParam("apply label", f.Action.AddLabel)
 	w.WriteParam("forward to", f.Action.Forward)
+
+	return w.String()
+}
+
+// DebugString returns text representation of the filter with extra debugging
+// information Gmail search representation and URL included.
+func (f Filter) DebugString() string {
+	w := writer{}
+
+	w.WriteString(fmt.Sprintf("# Search: %s\n", f.Criteria.ToGmailSearch()))
+	w.WriteString(fmt.Sprintf("# URL: %s\n", f.Criteria.ToGmailSearchURL()))
+	w.WriteString(f.String())
 
 	return w.String()
 }
@@ -212,6 +240,13 @@ func (c Criteria) ToGmailSearch() string {
 	}
 
 	return strings.Join(res, " ")
+}
+
+// ToGmailSearchURL returns the equivalent query in an URL to Gmail search.
+func (c Criteria) ToGmailSearchURL() string {
+	return fmt.Sprintf(
+		"https://mail.google.com/mail/u/0/#search/%s",
+		url.QueryEscape(c.ToGmailSearch()))
 }
 
 type writer struct {

--- a/internal/engine/filter/filter_test.go
+++ b/internal/engine/filter/filter_test.go
@@ -1,0 +1,49 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCriteria(t *testing.T) {
+	tests := []struct {
+		name           string
+		criteria       Criteria
+		gmailSearch    string
+		gmailSearchURL string
+	}{
+		{
+			name:           "from criteria",
+			criteria:       Criteria{From: "someone@gmail.com"},
+			gmailSearch:    "from:someone@gmail.com",
+			gmailSearchURL: "https://mail.google.com/mail/u/0/#search/from%3Asomeone%40gmail.com",
+		},
+		{
+			name: "complicated query",
+			criteria: Criteria{
+				Query: "{from:noreply@acme.com to:{me@google.com me@acme.com}}",
+			},
+			gmailSearch:    "{from:noreply@acme.com to:{me@google.com me@acme.com}}",
+			gmailSearchURL: "https://mail.google.com/mail/u/0/#search/%7Bfrom%3Anoreply%40acme.com+to%3A%7Bme%40google.com+me%40acme.com%7D%7D",
+		},
+		{
+			name: "all fileds",
+			criteria: Criteria{
+				From:    "someone@gmail.com",
+				To:      "me@gmail.com",
+				Subject: "Hello world",
+				Query:   "unsubscribe",
+			},
+			gmailSearch:    "from:someone@gmail.com to:me@gmail.com subject:Hello world unsubscribe",
+			gmailSearchURL: "https://mail.google.com/mail/u/0/#search/from%3Asomeone%40gmail.com+to%3Ame%40gmail.com+subject%3AHello+world+unsubscribe",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.criteria.ToGmailSearch(), tc.gmailSearch)
+			assert.Equal(t, tc.criteria.ToGmailSearchURL(), tc.gmailSearchURL)
+		})
+	}
+}

--- a/internal/graph/munkres.go
+++ b/internal/graph/munkres.go
@@ -24,18 +24,18 @@ const (
 )
 
 // Munkres (Hungarian algorithm) method to solve the assignment problem
-//  based on code by Bob Pilgrim from http://csclab.murraystate.edu/bob.pilgrim/445/munkres.html
-//  Note: this method runs in O(n³), in the worst case; therefore is not efficient for large matrix
-//   Example:
-//           $ | Clean  Sweep   Wash
-//      -------|--------------------
-//      Fry    |   [2]      3      3
-//      Leela  |     3    [2]      3
-//      Bender |     3      3    [2]
-//      minimum cost = 6
 //
-//  Note: cost will be minimised
+//	based on code by Bob Pilgrim from http://csclab.murraystate.edu/bob.pilgrim/445/munkres.html
+//	Note: this method runs in O(n³), in the worst case; therefore is not efficient for large matrix
+//	 Example:
+//	         $ | Clean  Sweep   Wash
+//	    -------|--------------------
+//	    Fry    |   [2]      3      3
+//	    Leela  |     3    [2]      3
+//	    Bender |     3      3    [2]
+//	    minimum cost = 6
 //
+//	Note: cost will be minimised
 type Munkres struct {
 
 	// main
@@ -80,7 +80,8 @@ func (o *Munkres) Init(nrow, ncol int) {
 }
 
 // SetCostMatrix sets cost matrix by copying from C to internal o.C
-//  Note: costs must be positive
+//
+//	Note: costs must be positive
 func (o *Munkres) SetCostMatrix(C [][]float64) {
 	o.Cori = C
 	for i := 0; i < o.nrowOri; i++ {
@@ -101,11 +102,12 @@ func (o *Munkres) SetCostMatrix(C [][]float64) {
 }
 
 // Run runs the iterative algorithm
-//  Output:
-//   o.Links -- will contain assignments, where len(assignments) == nrow and
-//              j := o.Links[i] means that i is assigned to j
-//              -1 means no assignment/link
-//   o.Cost -- will have the total cost by following links
+//
+//	Output:
+//	 o.Links -- will contain assignments, where len(assignments) == nrow and
+//	            j := o.Links[i] means that i is assigned to j
+//	            -1 means no assignment/link
+//	 o.Cost -- will have the total cost by following links
 func (o *Munkres) Run() {
 
 	// column matrix


### PR DESCRIPTION
When creating a complicated search criteria, it can be helpful to verify that it matches the emails. If you specify `--debug` on diff, apply, edit commands, URL to Gmail search will be displayed in the diff.

Fixes #407