### PR TITLE
Add context option for filter diffs

### DIFF
--- a/cmd/gmailctl/cmd/diff_cmd.go
+++ b/cmd/gmailctl/cmd/diff_cmd.go
@@ -6,11 +6,13 @@ import (
 	"github.com/spf13/cobra"
 
 	papply "github.com/mbrt/gmailctl/internal/engine/apply"
+	"github.com/mbrt/gmailctl/internal/errors"
 )
 
 var (
 	diffFilename string
 	diffDebug    bool
+	diffContext  int
 )
 
 // diffCmd represents the diff command
@@ -39,9 +41,14 @@ func init() {
 	// Flags and configuration settings
 	diffCmd.PersistentFlags().StringVarP(&diffFilename, "filename", "f", "", "configuration file")
 	diffCmd.PersistentFlags().BoolVarP(&diffDebug, "debug", "", false, "print extra debugging information")
+	diffCmd.PersistentFlags().IntVarP(&diffContext, "context", "", papply.DefaultContextLines, "number of lines of filter diff context to show")
 }
 
 func diff(path string) error {
+	if diffContext < 0 {
+		return errors.New("--context must be non-negative")
+	}
+
 	parseRes, err := parseConfig(path, "", false)
 	if err != nil {
 		return err
@@ -57,7 +64,7 @@ func diff(path string) error {
 		return err
 	}
 
-	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, diffDebug)
+	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, diffDebug, diffContext)
 	if err != nil {
 		return fmt.Errorf("cannot compare upstream with local config: %w", err)
 	}

--- a/cmd/gmailctl/cmd/edit_cmd.go
+++ b/cmd/gmailctl/cmd/edit_cmd.go
@@ -17,9 +17,10 @@ import (
 
 // Parameters
 var (
-	editFilename  string
-	editSkipTests bool
-	editDebug     bool
+	editFilename    string
+	editSkipTests   bool
+	editDebug       bool
+	editDiffContext int
 )
 
 var (
@@ -70,9 +71,14 @@ func init() {
 	editCmd.PersistentFlags().StringVarP(&editFilename, "filename", "f", "", "configuration file")
 	editCmd.Flags().BoolVarP(&editSkipTests, "yolo", "", false, "skip configuration tests")
 	editCmd.PersistentFlags().BoolVarP(&editDebug, "debug", "", false, "print extra debugging information")
+	editCmd.PersistentFlags().IntVarP(&editDiffContext, "diff-context", "", papply.DefaultContextLines, "number of lines of filter diff context to show")
 }
 
 func edit(path string, test bool) error {
+	if editDiffContext < 0 {
+		return errors.New("--diff-context must be non-negative")
+	}
+
 	// First make sure that Gmail can be contacted, so that we don't
 	// waste the user's time editing a config file that cannot be
 	// applied now.
@@ -223,7 +229,7 @@ func applyEdited(path, originalPath string, test bool, gmailapi *api.GmailAPI) e
 		return err
 	}
 
-	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, editDebug)
+	diff, err := papply.Diff(parseRes.Res.GmailConfig, upstream, editDebug, editDiffContext)
 	if err != nil {
 		return errors.New("comparing upstream with local config")
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -68,7 +68,7 @@ func TestIntegration(t *testing.T) {
 			require.Nil(t, err)
 
 			// Apply the diff.
-			d, err := apply.Diff(pres.GmailConfig, upres, false)
+			d, err := apply.Diff(pres.GmailConfig, upres, false, apply.DefaultContextLines)
 			require.Nil(t, err)
 			err = apply.Apply(d, gapi, true)
 			require.Nil(t, err)
@@ -139,7 +139,7 @@ func TestIntegrationImportExport(t *testing.T) {
 			require.Nil(t, err)
 
 			// Apply the diff.
-			d, err := apply.Diff(pres.GmailConfig, upres, false)
+			d, err := apply.Diff(pres.GmailConfig, upres, false, apply.DefaultContextLines)
 			require.Nil(t, err)
 			err = apply.Apply(d, gapi, true)
 			require.Nil(t, err)
@@ -174,10 +174,10 @@ func TestIntegrationImportExport(t *testing.T) {
 }
 
 func assertEmptyDiff(t *testing.T, local, remote apply.GmailConfig) {
-	d, err := apply.Diff(local, remote, false)
+	d, err := apply.Diff(local, remote, false, -1)
 	require.Nil(t, err)
-	assert.Empty(t, d.FiltersDiff)
-	assert.Empty(t, d.LabelsDiff)
+	assert.True(t, d.FiltersDiff.Empty())
+	assert.True(t, d.LabelsDiff.Empty())
 }
 
 func mustParseTime(layout, value string) time.Time {

--- a/internal/engine/apply/apply.go
+++ b/internal/engine/apply/apply.go
@@ -11,6 +11,9 @@ import (
 	"github.com/mbrt/gmailctl/internal/engine/parser"
 )
 
+// DefaultContextLines is the default number of lines of context to show in the filter diff.
+const DefaultContextLines = 5
+
 // GmailConfig represents a Gmail configuration.
 type GmailConfig struct {
 	Labels  label.Labels
@@ -113,13 +116,13 @@ func (d ConfigDiff) Validate() error {
 }
 
 // Diff computes the diff between local and upstream configuration.
-func Diff(local, upstream GmailConfig, debugInfo bool) (ConfigDiff, error) {
+func Diff(local, upstream GmailConfig, debugInfo bool, contextLines int) (ConfigDiff, error) {
 	res := ConfigDiff{
 		LocalConfig: local,
 	}
 	var err error
 
-	res.FiltersDiff, err = filter.Diff(upstream.Filters, local.Filters, debugInfo)
+	res.FiltersDiff, err = filter.Diff(upstream.Filters, local.Filters, debugInfo, contextLines)
 	if err != nil {
 		return res, fmt.Errorf("cannot compute filters diff: %w", err)
 	}


### PR DESCRIPTION
This adds a `--context` option to the `diff` subcommand and a `--diff-context` option to the `apply` and `edit` commands. The option allows the number of lines of diff context to be customized, which is helpful for verifying the correctness of changes to more complex filters.