### PR TITLE
Fix initialization of cfgDir

### DIFF
--- a/cmd/gmailctl/cmd/root_cmd.go
+++ b/cmd/gmailctl/cmd/root_cmd.go
@@ -56,7 +56,7 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgDir == "" {
+	if cfgDir != "" {
 		// Use config file from the flag.
 		return
 	}


### PR DESCRIPTION
It is erroring with the message `Error: configuring the main config directory: mkdir : no such file or directory` because of an inverted comparison accidentally introduced in commit f713dc603cbca2879fcff0c67eb877677d987765.