### PR TITLE
✨ Allowing to specify a port for OAuth server

### DIFF
--- a/cmd/gmailctl/cmd/api_provider.go
+++ b/cmd/gmailctl/cmd/api_provider.go
@@ -20,7 +20,7 @@ type GmailAPIProvider interface {
 	// ResetConfig cleans up the configuration.
 	ResetConfig(cfgDir string) error
 	// InitConfig initializes the configuration.
-	InitConfig(cfgDir string) error
+	InitConfig(cfgDir string, port int) error
 }
 
 // APIKeyProvider is the interface implemented by API providers with
@@ -34,7 +34,7 @@ type APIKeyProvider interface {
 // TokenRefresher allows to refresh API tokens if they are expired.
 type TokenRefresher interface {
 	// RefreshToken refreshes the token if it is expired.
-	RefreshToken(ctx context.Context, cfgDir string) error
+	RefreshToken(ctx context.Context, cfgDir string, port int) error
 }
 
 func openAPI() (*api.GmailAPI, error) {

--- a/cmd/gmailctl/cmd/init_cmd.go
+++ b/cmd/gmailctl/cmd/init_cmd.go
@@ -15,6 +15,7 @@ var (
 	initReset          bool
 	initRefreshExpired bool
 	initUpdateLib      bool
+	port               int
 )
 
 // initCmd represents the init command
@@ -48,6 +49,7 @@ func init() {
 	initCmd.Flags().BoolVar(&initReset, "reset", false, "Reset the configuration.")
 	initCmd.Flags().BoolVar(&initRefreshExpired, "refresh-expired", false, "Refresh auth token if expired.")
 	initCmd.Flags().BoolVar(&initUpdateLib, "update-lib", false, "Update the library file.")
+	initCmd.Flags().IntVar(&port, "port", 0, "OAuth server bind port (default is 0 meaning random port)")
 }
 
 func resetConfig() error {
@@ -62,7 +64,7 @@ func continueConfig() error {
 	if err := handleCfgDir(); err != nil {
 		return fmt.Errorf("configuring the main config directory: %w", err)
 	}
-	if err := APIProvider.InitConfig(cfgDir); err != nil {
+	if err := APIProvider.InitConfig(cfgDir, port); err != nil {
 		return err
 	}
 	fmt.Println("\nYou have correctly configured gmailctl to use Gmail APIs.")
@@ -71,7 +73,7 @@ func continueConfig() error {
 
 func refreshToken() error {
 	if rt, ok := APIProvider.(TokenRefresher); ok {
-		return rt.RefreshToken(context.Background(), cfgDir)
+		return rt.RefreshToken(context.Background(), cfgDir, port)
 	}
 	return nil
 }

--- a/cmd/gmailctl/localcred/oauth2_server.go
+++ b/cmd/gmailctl/localcred/oauth2_server.go
@@ -52,8 +52,8 @@ func newOauth2Server(expectedState string) *oauth2Server {
 }
 
 // Start the oauth2Server asynchronously.
-func (s *oauth2Server) Start() (string, error) {
-	l, err := net.Listen("tcp", ":0") //nolint:gosec
+func (s *oauth2Server) Start(port int) (string, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port)) //nolint:gosec
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Specifying a port is necessary when running in a Docker container 